### PR TITLE
switch to using GetWindowText

### DIFF
--- a/lib/win32/autogui/window.rb
+++ b/lib/win32/autogui/window.rb
@@ -141,7 +141,7 @@ module Autogui
       length == 0 ? '' : buffer[0..length - 1]
     end
 
-    # Window text (WM_GETTEXT)
+    # Window text (GetWindowText or WM_GETTEXT)
     #
     # @param [Number] max_length (2048)
     #
@@ -149,10 +149,23 @@ module Autogui
     #
     def text(max_length = 2048)
       buffer = "\0" * max_length
-      length = SendMessageA(handle, WM_GETTEXT, buffer.length, buffer)
+      length = if is_control?
+        SendMessageA(handle, WM_GETTEXT, buffer.length, buffer)
+      else
+        GetWindowText(handle, buffer, buffer.length)
+      end
+
       length == 0 ? '' : buffer[0..length - 1]
     end
     alias :title :text
+    
+    # Determines whether the specified window handle identifies a window or a control
+    #
+    # @return [Boolean]
+    #
+    def is_control?
+      (handle != 0) && (GetDlgCtrlID(handle) != 0)
+    end
 
     # Determines whether the specified window handle identifies an existing window
     #

--- a/lib/win32/autogui/windows/window.rb
+++ b/lib/win32/autogui/windows/window.rb
@@ -17,6 +17,7 @@ module Windows
     API.new('SetForegroundWindow', 'L', 'I', 'user32')
     API.new('SendMessageA', 'LIIP', 'I', 'user32')
     API.new('IsWindowVisible', 'L', 'I', 'user32')
+    API.new('GetDlgCtrlID', 'L', 'I', 'user32')
 
   end
 end


### PR DESCRIPTION
Hi

I've run into an issue where WM_GETTEXT would just hang everything. After some digging I found:

http://blogs.msdn.com/b/oldnewthing/archive/2003/08/21/54675.aspx

Switching out to GetWindowText fixed my instance of the freezing issue. It's not 100% guaranteed to work (as noted in the link above), but I think it's "safer."
